### PR TITLE
Added _ before %d when outputting pkgId's

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ func main() {
 			color = "paleturquoise"
 		}
 
-		fmt.Printf("%d [label=\"%s\" style=\"filled\" color=\"%s\"];\n", pkgId, pkgName, color)
+		fmt.Printf("_%d [label=\"%s\" style=\"filled\" color=\"%s\"];\n", pkgId, pkgName, color)
 
 		// Don't render imports from packages in Goroot
 		if pkg.Goroot && !*delveGoroot {
@@ -107,7 +107,7 @@ func main() {
 			}
 
 			impId := getId(imp)
-			fmt.Printf("%d -> %d;\n", pkgId, impId)
+			fmt.Printf("_%d -> _%d;\n", pkgId, impId)
 		}
 	}
 	fmt.Println("}")


### PR DESCRIPTION
GraphViz dot grammar specifies the lexical form of an ID with a regular expression that forbids IDs from starting with a digit (http://www.graphviz.org/doc/info/lang.html)
"dot" doesn't care, but some other software packages that read "dot" format graphs do care.
